### PR TITLE
Corfu small fixes

### DIFF
--- a/corfu/70001/README.md
+++ b/corfu/70001/README.md
@@ -8,7 +8,7 @@ rm ~/.injectived/config/genesis.json
 
 2. Download and apply new genesis
 ```
-aws s3 cp s3://injective-snapshots/testnet/genesis.json .
+aws s3 cp s3://injective-snapshots/testnet/genesis.json . --no-sign-request
 sha256sum genesis.json
 a4abe4e1f5511d4c2f821c1c05ecb44b493eec185c0eec13b1dcd03d36e1a779
 mv genesis.json ~/.injectived/config/

--- a/corfu/70001/config.toml
+++ b/corfu/70001/config.toml
@@ -212,7 +212,7 @@ external_address = ""
 seeds = ""
 
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = "0a2af0f999b08ccaf8825198d9aafb8b947c003f@k8s.testnet.p2p.injective.network:26656, d0c2407f4b1cef137d9d3ada69478234ad2a28f4@k8s.testnet.p2p.injective.network:26656"
+persistent_peers = "0a2af0f999b08ccaf8825198d9aafb8b947c003f@34.73.57.164:26656,d0c2407f4b1cef137d9d3ada69478234ad2a28f4@34.73.57.164:26656"
 
 # UPNP port forwarding
 upnp = false


### PR DESCRIPTION
- Updated readme to allow AWS clients without credentials to download the genesis file
- Updated the persistent peers in the `config.toml` file
- Added newlines to EOFs